### PR TITLE
Including leading dot in domains

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -110,7 +110,7 @@ func (h *handler) createRecord(w http.ResponseWriter, r *http.Request) {
 }
 
 func validateRecord(input model.RecordRequest) error {
-	if err := input.Type.IsValid(); err != nil {
+	if err := model.IsValidRecordType(input.Type); err != nil {
 		return err
 	}
 

--- a/pkg/backend/purger.go
+++ b/pkg/backend/purger.go
@@ -43,9 +43,9 @@ func (b *backend) purge() {
 			currentPageRecords := make(map[model.FQDNTypePair]*route53.ResourceRecordSet)
 			pairsToQuery := make(map[model.FQDNTypePair]bool)
 			for _, recordSet := range page.ResourceRecordSets {
-				if aws.StringValue(recordSet.Type) != string(model.RecordTypeA) &&
-					aws.StringValue(recordSet.Type) != string(model.RecordTypeCname) &&
-					aws.StringValue(recordSet.Type) != string(model.RecordTypeTxt) {
+				if aws.StringValue(recordSet.Type) != model.RecordTypeA &&
+					aws.StringValue(recordSet.Type) != model.RecordTypeCname &&
+					aws.StringValue(recordSet.Type) != model.RecordTypeTxt {
 					continue
 				}
 				// key is name (fqdn) + type

--- a/pkg/db/implementation.go
+++ b/pkg/db/implementation.go
@@ -82,7 +82,7 @@ func (d *database) CreateNewSubDomain(tokenHash, domainName string) (Domain, err
 		if slug == "" {
 			return fmt.Errorf("couldn't generate slug")
 		}
-		subDomain := fmt.Sprintf("%s.%s", slug, domainName)
+		subDomain := fmt.Sprintf(".%s.%s", slug, domainName)
 
 		domain = Domain{
 			TokenHash:   tokenHash,

--- a/pkg/model/domain.go
+++ b/pkg/model/domain.go
@@ -5,15 +5,13 @@ import (
 )
 
 const (
-	RecordTypeA     RecordType = "A"
-	RecordTypeAAAA  RecordType = "AAAA"
-	RecordTypeCname RecordType = "CNAME"
-	RecordTypeTxt   RecordType = "TXT"
+	RecordTypeA     = "A"
+	RecordTypeAAAA  = "AAAA"
+	RecordTypeCname = "CNAME"
+	RecordTypeTxt   = "TXT"
 )
 
-type RecordType string
-
-func (rt RecordType) IsValid() error {
+func IsValidRecordType(rt string) error {
 	switch rt {
 	case RecordTypeA, RecordTypeAAAA, RecordTypeCname, RecordTypeTxt:
 		return nil
@@ -37,9 +35,9 @@ type RenewResponse struct {
 }
 
 type RecordRequest struct {
-	Name   string     `json:"name,omitempty"`
-	Type   RecordType `json:"type,omitempty"`
-	Values []string   `json:"values,omitempty"`
+	Name   string   `json:"name,omitempty"`
+	Type   string   `json:"type,omitempty"`
+	Values []string `json:"values,omitempty"`
 }
 
 type RecordResponse struct {


### PR DESCRIPTION
For consistency, include the leading dot in the domains that are
created. This stops us from stripping it in some places and adding it
back in others.

Also, a few small cleanup items.
