### PR TITLE
Make renew response return short name

### DIFF
--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -31,7 +31,9 @@ type RenewRequest struct {
 }
 
 type RenewResponse struct {
-	Name             string         `json:"name,omitempty"`
+	Name string `json:"name,omitempty"`
+	// TODO - These records contain the "short" name, not the FQDN. Refactor the api to reflect that, but it needs
+	// to be coordinated with acorn.
 	OutOfSyncRecords []FQDNTypePair `json:"outOfSyncRecords,omitempty"`
 }
 


### PR DESCRIPTION
Acorn is expecting the response to the "renew" request to contain
out-of-sync records with their "SHORT" names rather than their FQDNs.

Addresses https://github.com/acorn-io/acorn/issues/754

Signed-off-by: Craig Jellick <craig@acorn.io>
