### PR TITLE
Elide "local" records from purge set

### DIFF
--- a/pkg/backend/purger.go
+++ b/pkg/backend/purger.go
@@ -71,6 +71,14 @@ func (b *backend) purge() {
 		return
 	}
 
+	// Elide records for "local" FQDNs, these won't exist in the database but shouldn't be deleted.
+	localSuffix := ".local." + b.baseDomain
+	for pair := range recordsToDelete {
+		if strings.HasSuffix(pair.FQDN, localSuffix) {
+			delete(recordsToDelete, pair)
+		}
+	}
+
 	if len(recordsToDelete) == 0 {
 		logrus.Infof("Records purged from Route53: 0")
 		return


### PR DESCRIPTION
Prevent records for "*.local.$BASE" domains from being deleted.

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
