### PR TITLE
Use JSON Formatter for logrus and add dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 acorn-dns
 acorn.sqlite
+.env

--- a/Acornfile
+++ b/Acornfile
@@ -18,14 +18,24 @@ args: {
 containers: {
 	"acorn-dns": {
 		if args.dbHost == "db" {
-		dependsOn: "db"
+			dependsOn: "db"
 		}
+
 		build: {
 			buildArgs: {
 				TAG: args.tag
 			}
 			context: "."
 		}
+
+		// Setup hot-reloading for api-server
+		if args.dev {
+			workdir: "/app"
+			image: "docker.io/cosmtrek/air" // https://github.com/cosmtrek/air
+			dirs: "/app": "./"
+			cmd: "api-server"
+		}
+
 		scale: args.scale
 		ports: "4315/http"
 		env: {
@@ -38,42 +48,45 @@ containers: {
 			ACORN_ROUTE53_ZONE_ID: args.route53ZoneId
 			AWS_ACCESS_KEY_ID: "secret://aws-creds/access-key?onchange=no-action"
 			AWS_SECRET_ACCESS_KEY: "secret://aws-creds/secret-key?onchange=no-action"
+			AWS_SESSION_TOKEN: "secret://aws-creds/session-token?onchange=no-action"
 		}
 	},
     if args.dbHost == "db" {
-	db: {
-		image: "mariadb:10.7.4"
-		env: {
-			MARIADB_ROOT_PASSWORD: "secret://root-credentials/password?onchange=no-action"
-			MARIADB_USER:          "secret://db-user-credentials/username?onchange=no-action"
-			MARIADB_PASSWORD:      "secret://db-user-credentials/password?onchange=no-action"
-			MARIADB_DATABASE:      args.dbName
+		db: {
+			image: "mariadb:10.7.4"
+			env: {
+				MARIADB_ROOT_PASSWORD: "secret://root-credentials/password?onchange=no-action"
+				MARIADB_USER:          "secret://db-user-credentials/username?onchange=no-action"
+				MARIADB_PASSWORD:      "secret://db-user-credentials/password?onchange=no-action"
+				MARIADB_DATABASE:      args.dbName
+			}
+			ports: "3306/tcp"
 		}
-		ports: "3306/tcp"
-	}
 	}
 }
 
 secrets: {
 	if args.dbHost == "db" {
-	"root-credentials": {
-		type: "basic"
-		data: {
-			username: "root"
+		"root-credentials": {
+			type: "basic"
+			data: {
+				username: "root"
+			}
+		}
+		"db-user-credentials": {
+			type: "basic"
+			data: {
+				username: "acorn"
+			}
 		}
 	}
-	"db-user-credentials": {
-		type: "basic"
-		data: {
-			username: "acorn"
-		}
-	}
-	}
+
 	"aws-creds": {
 		type: "opaque"
 		data: {
 			"access-key": ""
 			"secret-key": ""
+			"session-token": ""
 		}
 	}
 }

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ validate:
 
 test:
 	go test ./...
+
+dev:
+	./scripts/dev.sh

--- a/README.md
+++ b/README.md
@@ -33,7 +33,5 @@ OPTIONS:
    --db-port value                     Database port [$ACORN_DB_PORT]
    --log-level value, -l value         Log Level (default: "info") [$LOGLEVEL]
    --log-caller                        log the caller (aka line number and file) (default: false)
-   --log-disable-color                 disable log coloring (default: false)
-   --log-full-timestamp                force log output to always show full timestamp (default: false)
    --help, -h                          show help (default: false)
 ```

--- a/main.go
+++ b/main.go
@@ -5,13 +5,13 @@ import (
 	"path"
 
 	"github.com/acorn-io/acorn-dns/pkg/commands"
-	_ "github.com/acorn-io/acorn-dns/pkg/commands"
 	"github.com/acorn-io/acorn-dns/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
 	defer func() {
 		if r := recover(); r != nil {
 			// log panics forces exit

--- a/pkg/commands/global.go
+++ b/pkg/commands/global.go
@@ -22,24 +22,14 @@ func GlobalFlags() []cli.Flag {
 			Name:  "log-caller",
 			Usage: "log the caller (aka line number and file)",
 		},
-		&cli.BoolFlag{
-			Name:  "log-disable-color",
-			Usage: "disable log coloring",
-		},
-		&cli.BoolFlag{
-			Name:  "log-full-timestamp",
-			Usage: "force log output to always show full timestamp",
-		},
 	}
 
 	return globalFlags
 }
 
 func Before(c *cli.Context) error {
-	formatter := &logrus.TextFormatter{
-		DisableColors: c.Bool("log-disable-color"),
-		FullTimestamp: c.Bool("log-full-timestamp"),
-	}
+	formatter := &logrus.JSONFormatter{}
+
 	if c.Bool("log-caller") {
 		logrus.SetReportCaller(true)
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,35 @@
+# Ensure that the AWS credentials are set before proceeding
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    echo "AWS_ACCESS_KEY_ID is not set, please set it and try again"
+    exit 1
+fi
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "AWS_SECRET_ACCESS_KEY is not set, please set it and try again"
+    exit 1
+fi
+if [ -z "$AWS_SESSION_TOKEN" ]; then
+    echo "AWS_SESSION_TOKEN is not set, please set it and try again"
+    exit 1
+fi
+
+# Replace the current aws-creds secret if it exists
+acorn secrets aws-creds > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "aws-creds secret already exists, deleting it..."
+    acorn secret rm aws-creds > /dev/null 2>&1
+fi
+
+acorn secret create aws-creds \
+	--data access-key=$AWS_ACCESS_KEY_ID \
+	--data secret-key=$AWS_SECRET_ACCESS_KEY \
+	--data session-token=$AWS_SESSION_TOKEN \
+    > /dev/null
+
+# Ensure that the ROUTE53_ZONE_ID is set before proceeding
+if [ -z "$ROUTE53_ZONE_ID" ]; then
+    echo "ROUTE53_ZONE_ID is not set, please set it and try again"
+    exit 1
+fi
+
+# Hand-off start to acorn and link the aws-creds secret
+acorn dev -p 4315:4315 -s aws-creds:aws-creds . --route53-zone-id $ROUTE53_ZONE_ID


### PR DESCRIPTION
for #72 

This PR does 3 main things (each with their own commits):
1. Tells logrus to use its JSON formatter
2. Adds dev mode compatibility for the `Acornfile`
3. Moves successful route calls down to the debug log level.
