### PR TITLE
fix: Prevent erroneous purge of wildcard records

### DIFF
--- a/pkg/backend/purger.go
+++ b/pkg/backend/purger.go
@@ -43,6 +43,9 @@ func (b *backend) purge() {
 					aws.StringValue(recordSet.Type) != model.RecordTypeTxt {
 					continue
 				}
+
+				cleanedName := strings.Replace(aws.StringValue(recordSet.Name), "\\052", "*", 1)
+				recordSet.Name = aws.String(cleanedName)
 				// key is name (fqdn) + type
 				pair := model.FQDNTypePair{
 					FQDN: strings.TrimSuffix(aws.StringValue(recordSet.Name), "."),


### PR DESCRIPTION
We were incorrectly purging wildcard records because of a mistmatched
between what route53 returned and acorn-dns had in its DB. Route53
stores and returns `*` (the wildcard) as `\052`. So, when we did the
comaprison between the record from R53 and the record in the DB, we were
not finding a match and deciding to purge the record for R53.

This fixes the problem by just normalizing the record returned by R53 to
have `*`. Note that R53 accepts `*` just fine and as an equivalent to
`\052`, so when we actually SHOULD delete a wildcard record, this works
as expected.


@tylerslaton if you feel like playing with this tomorrow, you can start acorn-dns up with params that will put it on a really tight record purging loop via:
```
api-server --purge-interval-seconds 10 --record-max-age-seconds 60
```
That will run the purge loop every 10 seconds and delete records after they are 60 seconds old. So, if you were to use postman to create a wildcard record, you should see it live for about 60 seconds and then get deleted.

Signed-off-by: Craig Jellick <craig@acorn.io>
