### PR TITLE
Offload handleError logging to loggingMiddleware

### DIFF
--- a/pkg/apiserver/responsewriter.go
+++ b/pkg/apiserver/responsewriter.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/acorn-io/acorn-dns/pkg/model"
-	"github.com/sirupsen/logrus"
 )
 
 func writeErrorResponse(w http.ResponseWriter, httpStatus int, message string, data interface{}) {
@@ -22,7 +21,6 @@ func writeErrorResponse(w http.ResponseWriter, httpStatus int, message string, d
 }
 
 func handleError(w http.ResponseWriter, httpStatus int, err error) {
-	logrus.Errorf("Error during request: %v", err)
 	writeErrorResponse(w, httpStatus, err.Error(), nil)
 }
 


### PR DESCRIPTION
This updates the loggingMiddleware to grab the body of error responses and logs them now. Before this PR, this was done in the `handleError` function and resulted in 2 separate logs indicating errors. This also updates the error log to have proper fields.